### PR TITLE
Fixed issue screenshooting with illegal characters in path

### DIFF
--- a/Zukini.UI/UIHooks.cs
+++ b/Zukini.UI/UIHooks.cs
@@ -133,9 +133,9 @@ namespace Zukini.UI
             var title = this.ScenarioContext.ScenarioInfo.Title.Replace(" ", "");
             var propertyBucket = ObjectContainer.Resolve<PropertyBucket>();
 
-            return String.Format("{0}_{1}_{2}.png", feature, title, propertyBucket.TestId);
+            var name = $"{feature}_{title}_{propertyBucket.TestId}.png";
+            var finalName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            return finalName;
         }
-
-
     }
 }


### PR DESCRIPTION
Fixed issue with Invalid File Name chars in screenshot file name. Example: scenario title contains '>' sign.

![capture](https://user-images.githubusercontent.com/4210968/31286015-c0a7f1aa-aa71-11e7-8397-1201006e7012.PNG)
