### PR TITLE
View factory - convenient approach to page objects

### DIFF
--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -77,3 +77,6 @@ Scenario: I want to demonstrate view factory can wait for pages
 @viewfactory
 Scenario: I want to demonstrate view factory can work with components
 	Given I navigate to some page with components
+	Then I can see a video object with title 'Bohemian Rhapsody'
+	When I click play for Star Wars video
+	Then player controls appear in Star Wars video player

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -81,3 +81,12 @@ Scenario: I want to demonstrate view factory can work with components
 	When I click play for 'Star Wars' video
 	Then player controls appear in 'Star Wars' video player
 
+@viewfactory @page_component
+Scenario: I want to demostrate view factory can create many components
+	Given I navigate to some page with components
+	Then I can load '2' gallery components with view factory
+	And I can find gallery component using view factory with title 'Image 2'
+
+@viewfactory @page_component
+Scenario: I want to demostrate view factory fails when no expected component present
+	Then exception appear if I load component with view factory that does not exist

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -72,11 +72,12 @@ Scenario: I want to demonstrate view factory can wait for pages
 	Given I navigate to some page with delayed element
 	Then view factory can wait for delayed page
 	And  view factory throws an exception on attempt to load different page object
-	But  view factory can get different page object without loading it
+	But  view factory can get different page object without waiting for it
 
-@viewfactory
+@viewfactory @page_component
 Scenario: I want to demonstrate view factory can work with components
 	Given I navigate to some page with components
 	Then I can see a video object with title 'Rhapsody'
 	When I click play for 'Star Wars' video
 	Then player controls appear in 'Star Wars' video player
+

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -77,6 +77,6 @@ Scenario: I want to demonstrate view factory can wait for pages
 @viewfactory
 Scenario: I want to demonstrate view factory can work with components
 	Given I navigate to some page with components
-	Then I can see a video object with title 'Bohemian Rhapsody'
-	When I click play for Star Wars video
-	Then player controls appear in Star Wars video player
+	Then I can see a video object with title 'Rhapsody'
+	When I click play for 'Star Wars' video
+	Then player controls appear in 'Star Wars' video player

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -67,9 +67,13 @@ Scenario: WaitForNavigation does not timeout
 	Given I try to navigate to Google
 	Then navigation does not timeout
 
-@google_search @viewfactory
-Scenario: I want to demonstrate view factory
-	Given I navigate to W3Schools table reference page
-	Then view factory can load W3Schools table reference page
-	And  view factory throws an exception on attempt to load different page
-	But I can get different page object with view factory without loading it
+@viewfactory
+Scenario: I want to demonstrate view factory can wait for pages
+	Given I navigate to some page with delayed element
+	Then view factory can wait for delayed page
+	And  view factory throws an exception on attempt to load different page object
+	But  view factory can get different page object without loading it
+
+@viewfactory
+Scenario: I want to demonstrate view factory can work with components
+	Given I navigate to some page with components

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -66,3 +66,10 @@ Scenario: WaitForNavigation does timeout
 Scenario: WaitForNavigation does not timeout
 	Given I try to navigate to Google
 	Then navigation does not timeout
+
+@google_search @viewfactory
+Scenario: I want to demonstrate view factory
+	Given I navigate to W3Schools table reference page
+	Then view factory can load W3Schools table reference page
+	And  view factory throws an exception on attempt to load different page
+	But I can get different page object with view factory without loading it

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature
@@ -71,13 +71,11 @@ Scenario: WaitForNavigation does not timeout
 Scenario: I want to demonstrate view factory can wait for pages
 	Given I navigate to some page with delayed element
 	Then view factory can wait for delayed page
-	And  view factory throws an exception on attempt to load different page object
-	But  view factory can get different page object without waiting for it
-
+	
 @viewfactory @page_component
-Scenario: I want to demonstrate view factory can work with components
+Scenario: I want to demonstrate view factory can work with complex components
 	Given I navigate to some page with components
-	Then I can see a video object with title 'Rhapsody'
+	Then I can find a youtube video component with title 'Rhapsody'
 	When I click play for 'Star Wars' video
 	Then player controls appear in 'Star Wars' video player
 
@@ -88,5 +86,6 @@ Scenario: I want to demostrate view factory can create many components
 	And I can find gallery component using view factory with title 'Image 2'
 
 @viewfactory @page_component
-Scenario: I want to demostrate view factory fails when no expected component present
-	Then exception appear if I load component with view factory that does not exist
+Scenario: I want to demostrate view factory fails when no expected page or component present
+	Then view factory throws an exception on attempt to load page object that is never loaded
+	And view factory throws an exception on attempt to load page component that is never loaded

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -254,6 +254,29 @@ this.ScenarioSetup(scenarioInfo);
 #line hidden
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory")]
+        [NUnit.Framework.CategoryAttribute("google_search")]
+        [NUnit.Framework.CategoryAttribute("viewfactory")]
+        public virtual void IWantToDemonstrateViewFactory()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory", new string[] {
+                        "google_search",
+                        "viewfactory"});
+#line 71
+this.ScenarioSetup(scenarioInfo);
+#line 72
+ testRunner.Given("I navigate to W3Schools table reference page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 73
+ testRunner.Then("view factory can load W3Schools table reference page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 74
+ testRunner.And("view factory throws an exception on attempt to load different page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 75
+ testRunner.But("I can get different page object with view factory without loading it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
+#line hidden
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -298,6 +298,44 @@ this.ScenarioSetup(scenarioInfo);
 #line hidden
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("I want to demostrate view factory can create many components")]
+        [NUnit.Framework.CategoryAttribute("viewfactory")]
+        [NUnit.Framework.CategoryAttribute("page_component")]
+        public virtual void IWantToDemostrateViewFactoryCanCreateManyComponents()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demostrate view factory can create many components", new string[] {
+                        "viewfactory",
+                        "page_component"});
+#line 85
+this.ScenarioSetup(scenarioInfo);
+#line 86
+ testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 87
+ testRunner.Then("I can load \'2\' gallery components with view factory", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 88
+ testRunner.And("I can find gallery component using view factory with title \'Image 2\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("I want to demostrate view factory fails when no expected component present")]
+        [NUnit.Framework.CategoryAttribute("viewfactory")]
+        [NUnit.Framework.CategoryAttribute("page_component")]
+        public virtual void IWantToDemostrateViewFactoryFailsWhenNoExpectedComponentPresent()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demostrate view factory fails when no expected component present", new string[] {
+                        "viewfactory",
+                        "page_component"});
+#line 91
+this.ScenarioSetup(scenarioInfo);
+#line 92
+ testRunner.Then("exception appear if I load component with view factory that does not exist", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -271,7 +271,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 74
  testRunner.And("view factory throws an exception on attempt to load different page object", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 75
- testRunner.But("view factory can get different page object without loading it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
+ testRunner.But("view factory can get different page object without waiting for it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
 #line hidden
             this.ScenarioCleanup();
         }
@@ -279,10 +279,12 @@ this.ScenarioSetup(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory can work with components")]
         [NUnit.Framework.CategoryAttribute("viewfactory")]
+        [NUnit.Framework.CategoryAttribute("page_component")]
         public virtual void IWantToDemonstrateViewFactoryCanWorkWithComponents()
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory can work with components", new string[] {
-                        "viewfactory"});
+                        "viewfactory",
+                        "page_component"});
 #line 78
 this.ScenarioSetup(scenarioInfo);
 #line 79

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -268,32 +268,28 @@ this.ScenarioSetup(scenarioInfo);
  testRunner.Given("I navigate to some page with delayed element", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 73
  testRunner.Then("view factory can wait for delayed page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 74
- testRunner.And("view factory throws an exception on attempt to load different page object", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 75
- testRunner.But("view factory can get different page object without waiting for it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
 #line hidden
             this.ScenarioCleanup();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory can work with components")]
+        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory can work with complex components")]
         [NUnit.Framework.CategoryAttribute("viewfactory")]
         [NUnit.Framework.CategoryAttribute("page_component")]
-        public virtual void IWantToDemonstrateViewFactoryCanWorkWithComponents()
+        public virtual void IWantToDemonstrateViewFactoryCanWorkWithComplexComponents()
         {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory can work with components", new string[] {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory can work with complex components", new string[] {
                         "viewfactory",
                         "page_component"});
-#line 78
+#line 76
 this.ScenarioSetup(scenarioInfo);
-#line 79
+#line 77
  testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 80
- testRunner.Then("I can see a video object with title \'Rhapsody\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 81
+#line 78
+ testRunner.Then("I can find a youtube video component with title \'Rhapsody\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 79
  testRunner.When("I click play for \'Star Wars\' video", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 82
+#line 80
  testRunner.Then("player controls appear in \'Star Wars\' video player", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
@@ -308,31 +304,37 @@ this.ScenarioSetup(scenarioInfo);
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demostrate view factory can create many components", new string[] {
                         "viewfactory",
                         "page_component"});
-#line 85
+#line 83
 this.ScenarioSetup(scenarioInfo);
-#line 86
+#line 84
  testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 87
+#line 85
  testRunner.Then("I can load \'2\' gallery components with view factory", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 88
+#line 86
  testRunner.And("I can find gallery component using view factory with title \'Image 2\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("I want to demostrate view factory fails when no expected component present")]
+        [NUnit.Framework.DescriptionAttribute("I want to demostrate view factory fails when no expected page or component presen" +
+            "t")]
         [NUnit.Framework.CategoryAttribute("viewfactory")]
         [NUnit.Framework.CategoryAttribute("page_component")]
-        public virtual void IWantToDemostrateViewFactoryFailsWhenNoExpectedComponentPresent()
+        public virtual void IWantToDemostrateViewFactoryFailsWhenNoExpectedPageOrComponentPresent()
         {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demostrate view factory fails when no expected component present", new string[] {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demostrate view factory fails when no expected page or component presen" +
+                    "t", new string[] {
                         "viewfactory",
                         "page_component"});
-#line 91
+#line 89
 this.ScenarioSetup(scenarioInfo);
-#line 92
- testRunner.Then("exception appear if I load component with view factory that does not exist", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 90
+ testRunner.Then("view factory throws an exception on attempt to load page object that is never loa" +
+                    "ded", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 91
+ testRunner.And("view factory throws an exception on attempt to load page component that is never " +
+                    "loaded", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -256,24 +256,37 @@ this.ScenarioSetup(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory")]
-        [NUnit.Framework.CategoryAttribute("google_search")]
+        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory can wait for pages")]
         [NUnit.Framework.CategoryAttribute("viewfactory")]
-        public virtual void IWantToDemonstrateViewFactory()
+        public virtual void IWantToDemonstrateViewFactoryCanWaitForPages()
         {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory", new string[] {
-                        "google_search",
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory can wait for pages", new string[] {
                         "viewfactory"});
 #line 71
 this.ScenarioSetup(scenarioInfo);
 #line 72
- testRunner.Given("I navigate to W3Schools table reference page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+ testRunner.Given("I navigate to some page with delayed element", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 73
- testRunner.Then("view factory can load W3Schools table reference page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("view factory can wait for delayed page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 74
- testRunner.And("view factory throws an exception on attempt to load different page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("view factory throws an exception on attempt to load different page object", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 75
- testRunner.But("I can get different page object with view factory without loading it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
+ testRunner.But("view factory can get different page object without loading it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "But ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("I want to demonstrate view factory can work with components")]
+        [NUnit.Framework.CategoryAttribute("viewfactory")]
+        public virtual void IWantToDemonstrateViewFactoryCanWorkWithComponents()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to demonstrate view factory can work with components", new string[] {
+                        "viewfactory"});
+#line 78
+this.ScenarioSetup(scenarioInfo);
+#line 79
+ testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -287,6 +287,12 @@ this.ScenarioSetup(scenarioInfo);
 this.ScenarioSetup(scenarioInfo);
 #line 79
  testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 80
+ testRunner.Then("I can see a video object with title \'Bohemian Rhapsody\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 81
+ testRunner.When("I click play for Star Wars video", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 82
+ testRunner.Then("player controls appear in Star Wars video player", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
+++ b/Zukini.UI.Examples.Features/Features/SmokeTest.feature.cs
@@ -288,11 +288,11 @@ this.ScenarioSetup(scenarioInfo);
 #line 79
  testRunner.Given("I navigate to some page with components", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 80
- testRunner.Then("I can see a video object with title \'Bohemian Rhapsody\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("I can see a video object with title \'Rhapsody\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 81
- testRunner.When("I click play for Star Wars video", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.When("I click play for \'Star Wars\' video", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 82
- testRunner.Then("player controls appear in Star Wars video player", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("player controls appear in \'Star Wars\' video player", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/Zukini.UI.Examples.Features/Hooks.cs
+++ b/Zukini.UI.Examples.Features/Hooks.cs
@@ -9,6 +9,7 @@ using System.Configuration;
 using TechTalk.SpecFlow;
 using Zukini.UI.Examples.Features.CustomDrivers;
 using Zukini.UI;
+using Zukini.UI.Pages;
 
 namespace Zukini.UI.Examples.Features
 {
@@ -26,6 +27,9 @@ namespace Zukini.UI.Examples.Features
             _objectContainer = container;
             _sessionConfiguration = sessionConfig;
             _zukiniConfiguration = zukiniConfig;
+
+            // View factory binding
+            _objectContainer.RegisterInstanceAs<IViewFactory>(new ViewFactory(_objectContainer));
         }
 
         [BeforeScenario]

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -26,8 +26,7 @@ namespace Zukini.UI.Examples.Features.Steps
         [Given(@"I navigate to Google")]
         public void GivenINavigateToGoogle()
         {
-            //Browser.WaitForNavigation(_sessionConfiguration, TestSettings.GoogleUrl);
-            Browser.Visit(TestSettings.GoogleUrl);
+            Browser.WaitForNavigation(_sessionConfiguration, TestSettings.GoogleUrl);
         }
 
         [Given(@"I enter a search value of ""(.*)""")]
@@ -36,7 +35,7 @@ namespace Zukini.UI.Examples.Features.Steps
             _viewFactory.Load<GoogleSearchPage>().SearchTextBox.FillInWith(searchValue);
         }
         
-        [Then(@"view factory throws an exception on attempt to load different page")]
+        [Then(@"view factory throws an exception on attempt to load different page object")]
         public void ThenViewFactoryThrowsAnExceptionOnAttemptToLoadDifferentPage()
         {
             var ex = Assert.Throws<Exception>(() => _viewFactory.Load<GoogleSearchPage>());
@@ -48,7 +47,7 @@ namespace Zukini.UI.Examples.Features.Steps
             _viewFactory.Load<W3SchoolsTablePage>();
         }
 
-        [Then(@"I can get different page object with view factory without loading it")]
+        [Then(@"view factory can get different page object without loading it")]
         public void ThenICanGetDifferentPageObjectWithViewFactoryWithoutLoadingIt()
         {
             var page = _viewFactory.Get<GoogleSearchPage>();
@@ -167,6 +166,20 @@ namespace Zukini.UI.Examples.Features.Steps
         public void GivenITryToNavigateToAUrlThatChangesTheBrowserLocation()
         {
             PropertyBucket.Remember("NavigationTimedOut", NavigationTimedOut(TestSettings.GoogleHttpUrl));
+        }
+
+        [Given(@"I navigate to some page(?:.*)")]
+        public void GivenINavigateToSomePageWithDelayedElement()
+        {
+            _viewFactory.Get<FakePageObject>();
+        }
+
+        [Then(@"view factory can wait for delayed page")]
+        public void ThenViewFactoryCanLoadDelayedPage()
+        {
+            var page = _viewFactory.Load<FakePageObject>();
+            Assert.That(page.DelayedElement.Exists(), Is.True, 
+                "After navigating to fake page, view factory didn't wait for delayed element");
         }
 
         [Then(@"navigation (does|does not) timeout")]

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -38,7 +38,7 @@ namespace Zukini.UI.Examples.Features.Steps
         [Then(@"view factory throws an exception on attempt to load different page object")]
         public void ThenViewFactoryThrowsAnExceptionOnAttemptToLoadDifferentPage()
         {
-            var ex = Assert.Throws<Exception>(() => _viewFactory.Load<GoogleSearchPage>());
+            Assert.Throws<ZukiniAssertionException>(() => _viewFactory.Load<MissingFakePage>());
         }
 
         [Then(@"view factory can load W3Schools table reference page")]
@@ -201,6 +201,28 @@ namespace Zukini.UI.Examples.Features.Steps
         {
             var player = _viewFactory.Load<FakePageObject>().FindPlayerByTitle(title);
             Assert.That(player.Controls.Exists(), Is.True, "Controls doesn't appear after");
+        }
+        
+        [Then(@"I can load '(.*)' gallery components with view factory")]
+        public void ThenICanLoadGalleryComponentsWithViewFactory(int count)
+        {
+            var images = _viewFactory.Get<FakePageObject>().GalleryImages1;
+            Assert.That(images.Count(), Is.EqualTo(count), "Not all images loaded");
+        }
+
+        [Then(@"I can find gallery component using view factory with title '(.*)'")]
+        public void ThenICanFindGalleryComponentUsingViewFactoryWithTitle(string description)
+        {
+            var images = _viewFactory.Get<FakePageObject>().GalleryImages2;
+            var foundImg    = images.First(img => img.Desciption.Text == description);
+            Assert.That(foundImg, Is.Not.Null, "Image not found");
+        }
+
+        [Then(@"exception appear if I load component with view factory that does not exist")]
+        public void ThenExceptionAppearIfILoadComponentWithViewFactoryThatDoesNotExist()
+        {
+            Assert.Throws<ZukiniAssertionException>(() => 
+                _viewFactory.Load(() => new MissingFakeComponent(Browser)), "Exception does not appear for view factory.");
         }
 
         [Then(@"navigation (does|does not) timeout")]

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -32,26 +32,13 @@ namespace Zukini.UI.Examples.Features.Steps
         [Given(@"I enter a search value of ""(.*)""")]
         public void GivenIEnterASearchValueOf(string searchValue)
         {
-            _viewFactory.Load<GoogleSearchPage>().SearchTextBox.FillInWith(searchValue);
+            _viewFactory.Get<GoogleSearchPage>().SearchTextBox.FillInWith(searchValue);
         }
         
-        [Then(@"view factory throws an exception on attempt to load different page object")]
+        [Then(@"view factory throws an exception on attempt to load page object that is never loaded")]
         public void ThenViewFactoryThrowsAnExceptionOnAttemptToLoadDifferentPage()
         {
             Assert.Throws<ZukiniAssertionException>(() => _viewFactory.Load<MissingFakePage>());
-        }
-
-        [Then(@"view factory can load W3Schools table reference page")]
-        public void ThenViewFactoryCanLoadWSchoolsTableReferencePage()
-        {
-            _viewFactory.Load<W3SchoolsTablePage>();
-        }
-
-        [Then(@"view factory can get different page object without waiting for it")]
-        public void ThenICanGetDifferentPageObjectWithViewFactoryWithoutLoadingIt()
-        {
-            var page = _viewFactory.Get<GoogleSearchPage>();
-            Assert.IsNotNull(page, "Failed to create page");
         }
         
         [When(@"I press Google Search")]
@@ -75,7 +62,7 @@ namespace Zukini.UI.Examples.Features.Steps
         [Then(@"I should see that the table tag is supported in ""(.*)""")]
         public void ThenIShouldSeeThatTheTableTagIsSupportedIn(string browserName)
         {
-            var page = _viewFactory.Load<W3SchoolsTablePage>().AssertCurrentPage();
+            var page = _viewFactory.Get<W3SchoolsTablePage>().AssertCurrentPage();
             Assert.IsTrue(page.IsBrowserSupported(browserName), String.Format("Expected browser {0} to be supported.", browserName));
         }
 
@@ -182,7 +169,7 @@ namespace Zukini.UI.Examples.Features.Steps
                 "After navigating to fake page, view factory didn't wait for delayed element");
         }
 
-        [Then(@"I can see a video object with title '(.*)'")]
+        [Then(@"I can find a youtube video component with title '(.*)'")]
         public void ThenICanSeeAVideoObjectWithTitle(string partOfTitle)
         {
             var title = _viewFactory.Load<FakePageObject>().FindPlayerByTitle(partOfTitle).Title;
@@ -215,10 +202,10 @@ namespace Zukini.UI.Examples.Features.Steps
         {
             var images = _viewFactory.Get<FakePageObject>().GalleryImages2;
             var foundImg    = images.First(img => img.Desciption.Text == description);
-            Assert.That(foundImg, Is.Not.Null, "Image not found");
+            Assert.That(foundImg.Image.Exists(), Is.True, "Image not found");
         }
 
-        [Then(@"exception appear if I load component with view factory that does not exist")]
+        [Then(@"view factory throws an exception on attempt to load page component that is never loaded")]
         public void ThenExceptionAppearIfILoadComponentWithViewFactoryThatDoesNotExist()
         {
             Assert.Throws<ZukiniAssertionException>(() => 

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -185,21 +185,21 @@ namespace Zukini.UI.Examples.Features.Steps
         [Then(@"I can see a video object with title '(.*)'")]
         public void ThenICanSeeAVideoObjectWithTitle(string partOfTitle)
         {
-            var title = _viewFactory.Load<FakePageObject>().RapsodyPlayer.Title;
+            var title = _viewFactory.Load<FakePageObject>().FindPlayerByTitle(partOfTitle).Title;
             Assert.That(title.Text, Does.Contain(partOfTitle), "Wrong title");
         }
 
-        [When(@"I click play for Star Wars video")]
-        public void WhenIClickPlayForStarWarsVideo()
+        [When(@"I click play for '(.*)' video")]
+        public void WhenIClickPlayForStarWarsVideo(string title)
         {
-            var player = _viewFactory.Load<FakePageObject>().StarWardsPlayer;
+            var player = _viewFactory.Load<FakePageObject>().FindPlayerByTitle(title);
             player.PlayButton.Click();
         }
 
-        [Then(@"player controls appear in Star Wars video player")]
-        public void ThenPlayerControlsAppearInStarWarsVideoPlayer()
+        [Then(@"player controls appear in '(.*)' video player")]
+        public void ThenPlayerControlsAppearInStarWarsVideoPlayer(string title)
         {
-            var player = _viewFactory.Load<FakePageObject>().StarWardsPlayer;
+            var player = _viewFactory.Load<FakePageObject>().FindPlayerByTitle(title);
             Assert.That(player.Controls.Exists(), Is.True, "Controls doesn't appear after");
         }
 

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -182,6 +182,27 @@ namespace Zukini.UI.Examples.Features.Steps
                 "After navigating to fake page, view factory didn't wait for delayed element");
         }
 
+        [Then(@"I can see a video object with title '(.*)'")]
+        public void ThenICanSeeAVideoObjectWithTitle(string partOfTitle)
+        {
+            var title = _viewFactory.Load<FakePageObject>().RapsodyPlayer.Title;
+            Assert.That(title.Text, Does.Contain(partOfTitle), "Wrong title");
+        }
+
+        [When(@"I click play for Star Wars video")]
+        public void WhenIClickPlayForStarWarsVideo()
+        {
+            var player = _viewFactory.Load<FakePageObject>().StarWardsPlayer;
+            player.PlayButton.Click();
+        }
+
+        [Then(@"player controls appear in Star Wars video player")]
+        public void ThenPlayerControlsAppearInStarWarsVideoPlayer()
+        {
+            var player = _viewFactory.Load<FakePageObject>().StarWardsPlayer;
+            Assert.That(player.Controls.Exists(), Is.True, "Controls doesn't appear after");
+        }
+
         [Then(@"navigation (does|does not) timeout")]
         public void ThenNavigationWillTimeOut(string flag)
         {

--- a/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
+++ b/Zukini.UI.Examples.Features/Steps/SmokeTestSteps.cs
@@ -47,7 +47,7 @@ namespace Zukini.UI.Examples.Features.Steps
             _viewFactory.Load<W3SchoolsTablePage>();
         }
 
-        [Then(@"view factory can get different page object without loading it")]
+        [Then(@"view factory can get different page object without waiting for it")]
         public void ThenICanGetDifferentPageObjectWithViewFactoryWithoutLoadingIt()
         {
             var page = _viewFactory.Get<GoogleSearchPage>();

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using Coypu;
+using Zukini.UI.Pages;
+
+namespace Zukini.UI.Examples.Pages
+{
+    public class FakePageObject : BasePage<FakePageObject>
+    {
+        private readonly IViewFactory _viewFactory;
+
+        public FakePageObject(BrowserSession browser, IViewFactory viewFactory) : base(browser)
+        {
+            _viewFactory = viewFactory;
+            var script = ReadPageHtml();
+            browser.ExecuteScript(@"document.open();
+                           document.write(arguments[0]); 
+                           document.close();", 
+                           script);
+        }
+
+        public ElementScope Title => _.FindCss("h1");
+        public ElementScope DelayedElement => _.FindId("delayed");
+
+        public override bool IsLoaded()
+        {
+            return DelayedElement.Exists();
+        }
+        
+        private string ReadPageHtml()
+        {
+            var path = Path.Combine(Path.GetDirectoryName(System.AppDomain.CurrentDomain.BaseDirectory), "fake.html");
+            return File.ReadAllText(path);
+        }
+    }
+
+    public class FakeYouTubeComponent : BaseComponent<FakeYouTubeComponent>
+    {
+        public FakeYouTubeComponent(DriverScope browserScope) : base(browserScope){}
+        //public void Play
+    }
+}

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Coypu;
 using Zukini.UI.Pages;
 
 namespace Zukini.UI.Examples.Pages
 {
+    /// <summary>
+    /// Almost real page.
+    /// </summary>
     public class FakePageObject : BasePage<FakePageObject>
     {
         private readonly IViewFactory _viewFactory;
@@ -37,6 +41,9 @@ namespace Zukini.UI.Examples.Pages
             return File.ReadAllText(path);
         }
 
+        /// <summary>
+        /// Populates the page with DOM.
+        /// </summary>
         private void PopulatePageWithSomeContent()
         {
             var script = ReadPageHtml();
@@ -50,6 +57,12 @@ namespace Zukini.UI.Examples.Pages
         {
             return _viewFactory.Load(() => new YouTubeComponent(_.FindFrame(frameTitle)));
         }
+
+        public IEnumerable<GalleryImageComponent> GalleryImages1
+            => _viewFactory.LoadAll<GalleryImageComponent>(_.FindAllCss(".gallery"));
+
+        public IEnumerable<GalleryImageComponent> GalleryImages2
+            => _viewFactory.LoadAll(_.FindAllCss(".gallery"), el => new GalleryImageComponent(el));
     }
 
     /// <summary>
@@ -67,6 +80,34 @@ namespace Zukini.UI.Examples.Pages
         public override bool IsLoaded()
         {
             return Title.Exists();
+        }
+    }
+
+    public class GalleryImageComponent : BaseComponent<GalleryImageComponent>
+    {
+        public GalleryImageComponent(DriverScope browserScope) : base(browserScope){}
+
+        public ElementScope Desciption => _.FindCss(".desc");
+        public ElementScope Image => _.FindCss("img");
+    }
+    
+    public class MissingFakePage : BasePage<MissingFakePage>
+    {
+        public MissingFakePage(BrowserSession browser) : base(browser) { }
+
+        public override bool IsLoaded()
+        {
+            return false;
+        }
+    }
+
+    public class MissingFakeComponent : BaseComponent<MissingFakeComponent>
+    {
+        public MissingFakeComponent(DriverScope browserScope) : base(browserScope) { }
+
+        public override bool IsLoaded()
+        {
+            return false;
         }
     }
 }

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -41,18 +41,18 @@ namespace Zukini.UI.Examples.Pages
                            script);
         }
         
-        public FakeYouTubeComponent FindPlayerByTitle(string frameTitle)
+        public YouTubeComponent FindPlayerByTitle(string frameTitle)
         {
-            return _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame(frameTitle)));
+            return _viewFactory.Load(() => new YouTubeComponent(_.FindFrame(frameTitle)));
         }
     }
 
     /// <summary>
     /// Implementation of youtube page component
     /// </summary>
-    public class FakeYouTubeComponent : BaseComponent<FakeYouTubeComponent>
+    public class YouTubeComponent : BaseComponent<YouTubeComponent>
     {
-        public FakeYouTubeComponent(DriverScope browserScope) : base(browserScope){}
+        public YouTubeComponent(DriverScope browserScope) : base(browserScope){}
 
         public ElementScope Title => _.FindCss(".ytp-title");
         public ElementScope PlayButton => _.FindCss(".ytp-large-play-button");

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Coypu;
 using Zukini.UI.Pages;
 
@@ -28,7 +29,11 @@ namespace Zukini.UI.Examples.Pages
         
         private string ReadPageHtml()
         {
-            var path = Path.Combine(Path.GetDirectoryName(System.AppDomain.CurrentDomain.BaseDirectory), "fake.html");
+            var folder = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
+            if (folder == null)
+                throw new ArgumentException("Something went wrong. Cannot find project directory.");
+
+            var path = Path.Combine(folder, "fake.html");
             return File.ReadAllText(path);
         }
 

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Coypu;
 using Zukini.UI.Pages;
 
@@ -7,15 +10,14 @@ namespace Zukini.UI.Examples.Pages
     public class FakePageObject : BasePage<FakePageObject>
     {
         private readonly IViewFactory _viewFactory;
+        private readonly BrowserSession _browser;
 
         public FakePageObject(BrowserSession browser, IViewFactory viewFactory) : base(browser)
         {
             _viewFactory = viewFactory;
-            var script = ReadPageHtml();
-            browser.ExecuteScript(@"document.open();
-                           document.write(arguments[0]); 
-                           document.close();", 
-                           script);
+            _browser = browser;
+
+            PopulatePageWithSomeContent();
         }
 
         public ElementScope Title => _.FindCss("h1");
@@ -31,11 +33,26 @@ namespace Zukini.UI.Examples.Pages
             var path = Path.Combine(Path.GetDirectoryName(System.AppDomain.CurrentDomain.BaseDirectory), "fake.html");
             return File.ReadAllText(path);
         }
+
+        private void PopulatePageWithSomeContent()
+        {
+            var script = ReadPageHtml();
+            _browser.ExecuteScript(@"document.open();
+                           document.write(arguments[0]); 
+                           document.close();",
+                           script);
+        }
+
+        public FakeYouTubeComponent RapsodyPlayer => _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame("Rhapsody")));
+        public FakeYouTubeComponent StarWardsPlayer => _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame("Star Wars")));
     }
 
     public class FakeYouTubeComponent : BaseComponent<FakeYouTubeComponent>
     {
         public FakeYouTubeComponent(DriverScope browserScope) : base(browserScope){}
-        //public void Play
+
+        public ElementScope Title => _.FindCss(".ytp-title");
+        public ElementScope PlayButton => _.FindCss(".ytp-large-play-button");
+        public ElementScope Controls => _.FindCss("[class*=controls] [class*=time-display]");
     }
 }

--- a/Zukini.UI.Examples.Pages/FakePageObject.cs
+++ b/Zukini.UI.Examples.Pages/FakePageObject.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using Coypu;
 using Zukini.UI.Pages;
 
@@ -23,6 +20,7 @@ namespace Zukini.UI.Examples.Pages
         public ElementScope Title => _.FindCss("h1");
         public ElementScope DelayedElement => _.FindId("delayed");
 
+        /// Being polled for DelayedElement to exist if ViewFactory#Load is called.
         public override bool IsLoaded()
         {
             return DelayedElement.Exists();
@@ -42,11 +40,16 @@ namespace Zukini.UI.Examples.Pages
                            document.close();",
                            script);
         }
-
-        public FakeYouTubeComponent RapsodyPlayer => _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame("Rhapsody")));
-        public FakeYouTubeComponent StarWardsPlayer => _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame("Star Wars")));
+        
+        public FakeYouTubeComponent FindPlayerByTitle(string frameTitle)
+        {
+            return _viewFactory.Load(() => new FakeYouTubeComponent(_.FindFrame(frameTitle)));
+        }
     }
 
+    /// <summary>
+    /// Implementation of youtube page component
+    /// </summary>
     public class FakeYouTubeComponent : BaseComponent<FakeYouTubeComponent>
     {
         public FakeYouTubeComponent(DriverScope browserScope) : base(browserScope){}
@@ -54,5 +57,11 @@ namespace Zukini.UI.Examples.Pages
         public ElementScope Title => _.FindCss(".ytp-title");
         public ElementScope PlayButton => _.FindCss(".ytp-large-play-button");
         public ElementScope Controls => _.FindCss("[class*=controls] [class*=time-display]");
+
+        /// Being polled for DelayedElement to exist if ViewFactory#Load is called.
+        public override bool IsLoaded()
+        {
+            return Title.Exists();
+        }
     }
 }

--- a/Zukini.UI.Examples.Pages/GoogleSearchPage.cs
+++ b/Zukini.UI.Examples.Pages/GoogleSearchPage.cs
@@ -3,14 +3,16 @@ using Zukini.UI.Pages;
 
 namespace Zukini.UI.Examples.Pages
 {
-    public class GoogleSearchPage : BasePage
+    public class GoogleSearchPage : BasePage<GoogleSearchPage>
     {
-        public GoogleSearchPage(BrowserSession browser)
-            : base(browser)
-        { 
-        }
+        public GoogleSearchPage(BrowserSession browser) : base(browser) {}
 
-        public ElementScope SearchTextBox { get { return Browser.FindField("q"); } }
-        public ElementScope SearchButton { get { return Browser.FindButton("Search", Options.First); } }
+        public ElementScope SearchTextBox => _.FindField("q");
+        public ElementScope SearchButton  => _.FindButton("Search", Options.First);
+        
+        public override bool IsLoaded()
+        {
+            return SearchTextBox.Exists();
+        }
     }
 }

--- a/Zukini.UI.Examples.Pages/GoogleSearchPage.cs
+++ b/Zukini.UI.Examples.Pages/GoogleSearchPage.cs
@@ -9,10 +9,5 @@ namespace Zukini.UI.Examples.Pages
 
         public ElementScope SearchTextBox => _.FindField("q");
         public ElementScope SearchButton  => _.FindButton("Search", Options.First);
-        
-        public override bool IsLoaded()
-        {
-            return SearchTextBox.Exists();
-        }
     }
 }

--- a/Zukini.UI.Examples.Pages/W3SchoolsTablePage.cs
+++ b/Zukini.UI.Examples.Pages/W3SchoolsTablePage.cs
@@ -5,21 +5,27 @@ using Zukini.UI.Pages;
 
 namespace Zukini.UI.Examples.Pages
 {
-    public class W3SchoolsTablePage : BasePage
+    public class W3SchoolsTablePage : BasePage<W3SchoolsTablePage>
     {
         private const string PageTitle = "HTML table tag";
 
-        public ElementScope BrowserReferenceTable { get { return Browser.FindCss(".browserref"); } }
-        public ElementScope TopTextDiv { get { return Browser.FindCss(".toptext"); } }
+        public ElementScope BrowserReferenceTable => _.FindCss(".browserref");
+        public ElementScope TopTextDiv => _.FindCss(".toptext");
+        private readonly IViewFactory _vF;
 
-        public W3SchoolsTablePage(BrowserSession browserSession)
-            : base(browserSession)
+        public W3SchoolsTablePage(BrowserSession browserSession, IViewFactory vF) : base(browserSession)
         {
+            _vF = vF;
         }
 
-        public void AssertCurrentPage()
+        public W3SchoolsTablePage AssertCurrentPage()
         {
-            AssertCurrentPage("W3Schools Table", Browser.Title == PageTitle);
+            return AssertCurrentPage("W3Schools Table", Browser.Title == PageTitle);
+        }
+
+        public override bool IsLoaded()
+        {
+            return Browser.Title == PageTitle;
         }
 
         public bool IsBrowserSupported(string browserName)

--- a/Zukini.UI.Examples.Pages/Zukini.UI.Examples.Pages.csproj
+++ b/Zukini.UI.Examples.Pages/Zukini.UI.Examples.Pages.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BrowserName.cs" />
+    <Compile Include="FakePageObject.cs" />
     <Compile Include="GoogleSearchPage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="W3SchoolsTablePage.cs" />
@@ -71,6 +72,11 @@
       <Project>{8e5638a8-13da-4f84-b2a7-4ab79a534e12}</Project>
       <Name>Zukini.UI</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="fake.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Zukini.UI.Examples.Pages/fake.html
+++ b/Zukini.UI.Examples.Pages/fake.html
@@ -1,0 +1,42 @@
+﻿<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Fake PageObject</h1>
+
+<h2>Individuals and interactions over processes and tools</h2>
+<h3>Working software over comprehensive documentation</h3>
+<h4>Customer collaboration over contract negotiation</h4>
+<h5>Responding to change over following a plan</h5>
+<h6>Taken from <a href="http://agilemanifesto.org/">http://agilemanifesto.org/</a></h6>
+
+<button type="button" onclick="document.getElementById('demo').innerHTML = Date()">
+Date and Time</button>
+
+<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+
+<iframe width="420" height="315" src="https://www.youtube.com/embed/tgbNymZ7vqY"></iframe> 
+
+<iframe width="420" height="315" src="https://www.youtube.com/embed/nohQReM7BpI"></iframe> 
+
+<script>
+createButtonToClick(); 
+
+function createButtonToClick() { 
+  setTimeout( createDelayedButton, 2000 );
+  document.getElementsByTagName("body")[0].appendChild(button); } 
+
+  function createDelayedButton() { 
+     var button = document.createElement("button"); 
+     button.id = "delayed"; 
+     button.innerHTML = "Delayed button"; 
+     document.getElementsByTagName("body")[0].appendChild(button); 
+}
+
+
+</script>
+
+<p id="demo"></p>
+
+</body>
+</html> 

--- a/Zukini.UI.Examples.Pages/fake.html
+++ b/Zukini.UI.Examples.Pages/fake.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 
-<h1>Fake PageObject</h1>
+<h1>Almost real PageObject</h1>
 
 <h2>Individuals and interactions over processes and tools</h2>
 <h3>Working software over comprehensive documentation</h3>

--- a/Zukini.UI.Examples.Pages/fake.html
+++ b/Zukini.UI.Examples.Pages/fake.html
@@ -15,9 +15,9 @@ Date and Time</button>
 
 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/tgbNymZ7vqY"></iframe> 
+<iframe width="420" height="315" title = "Rhapsody" src="https://www.youtube.com/embed/tgbNymZ7vqY"></iframe> 
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/nohQReM7BpI"></iframe> 
+<iframe width="420" height="315" title = "Star Wars" src="https://www.youtube.com/embed/nohQReM7BpI"></iframe> 
 
 <script>
 createButtonToClick(); 

--- a/Zukini.UI.Examples.Pages/fake.html
+++ b/Zukini.UI.Examples.Pages/fake.html
@@ -1,22 +1,67 @@
 ﻿<!DOCTYPE html>
 <html>
+
+<head>
+<style>
+div.gallery {
+    margin: 5px;
+    border: 1px solid #ccc;
+    float: left;
+    width: 180px;
+}
+
+div.gallery:hover {
+    border: 1px solid #777;
+}
+
+div.gallery img {
+    width: 100%;
+    height: auto;
+}
+
+div.desc {
+    padding: 15px;
+    text-align: center;
+}
+</style>
+</head>
+
 <body>
 
-<h1>Almost real PageObject</h1>
-
+<h1>Almost real Page</h1>
 <h2>Individuals and interactions over processes and tools</h2>
 <h3>Working software over comprehensive documentation</h3>
 <h4>Customer collaboration over contract negotiation</h4>
 <h5>Responding to change over following a plan</h5>
 <h6>Taken from <a href="http://agilemanifesto.org/">http://agilemanifesto.org/</a></h6>
+    
+<div class="gallery">
+  <a target="_blank" href="https://www.w3schools.com/css/img_forest.jpg">
+    <img src="https://www.w3schools.com/css/img_forest.jpg" alt="Forest" width="300" height="200">
+  </a>
+  <div class="desc">Image 1</div>
+</div>
 
-<button type="button" onclick="document.getElementById('demo').innerHTML = Date()">
-Date and Time</button>
+<div class="gallery">
+  <a target="_blank" href="https://www.w3schools.com/css/img_lights.jpg">
+    <img src="https://www.w3schools.com/css/img_lights.jpg" alt="Mountains" width="300" height="200">
+  </a>
+  <div class="desc">Image 2</div>
+</div>
 
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+<p>
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p>
+
+<p>
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p>
+
+<p>
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p>
 
 <iframe width="420" height="315" title = "Rhapsody" src="https://www.youtube.com/embed/tgbNymZ7vqY"></iframe> 
-
 <iframe width="420" height="315" title = "Star Wars" src="https://www.youtube.com/embed/nohQReM7BpI"></iframe> 
 
 <script>
@@ -32,8 +77,6 @@ function createButtonToClick() {
      button.innerHTML = "Delayed button"; 
      document.getElementsByTagName("body")[0].appendChild(button); 
 }
-
-
 </script>
 
 <p id="demo"></p>

--- a/Zukini.UI/Pages/BaseComponent.cs
+++ b/Zukini.UI/Pages/BaseComponent.cs
@@ -1,0 +1,23 @@
+﻿using Coypu;
+
+namespace Zukini.UI.Pages
+{
+    public abstract class BaseComponent<TView> : BaseView<TView> where TView : BaseComponent<TView>
+    {
+        private readonly DriverScope _parentScope;
+        
+        /// <summary>
+        /// Standalone component? Scope is browserScope.
+        /// </summary>
+        /// <param name="browserScope">BrowserSession</param>
+        public BaseComponent(DriverScope browserScope) : base(browserScope)
+        {
+            _parentScope = browserScope;
+        }
+
+        /// <summary>
+        /// Locator will look inside parent scope.
+        /// </summary>
+        protected override DriverScope _ => _parentScope;
+    }
+}

--- a/Zukini.UI/Pages/BasePage.cs
+++ b/Zukini.UI/Pages/BasePage.cs
@@ -3,32 +3,21 @@ using System;
 
 namespace Zukini.UI.Pages
 {
-    public class BasePage
+    public abstract class BasePage<TPage> : BaseView<TPage> where TPage : BasePage<TPage>
     {
         private readonly BrowserSession _browser;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasePage"/> class.
         /// </summary>
-        /// <param name="driver">An initialized instance of the WebDriver.</param>
+        /// <param name="browser">An initialized instance of the WebDriver.</param>
         /// <exception cref="System.ArgumentNullException">driver</exception>
-        public BasePage(BrowserSession browser)
-        {
-            if (browser == null)
-            {
-                throw new ArgumentNullException("driver");
-            }
-
-            _browser = browser;
-        }
+        public BasePage(DriverScope browser) : base(browser){}
 
         /// <summary>
         /// Provides access to the BrowserSession (as provided by Coypu).
         /// </summary>
-        protected BrowserSession Browser
-        {
-            get { return _browser; }
-        }
+        protected virtual BrowserSession Browser => _browser;
 
         /// <summary>
         /// Asserts that we are on the proper current page by searching for an element 
@@ -37,11 +26,27 @@ namespace Zukini.UI.Pages
         /// <param name="pageName">Name of the page to find (for messaging purposes.</param>
         /// <param name="condition"><c>true</c> if the page exists, or <c>false</c> if the page assertion fails.</param>
         /// <exception cref="Zukini.PageSupport.CurrentPageException"></exception>
-        protected void AssertCurrentPage(string pageName, bool condition)
+        protected virtual void AssertCurrentPage(string pageName, bool condition)
         {
             if (!condition)
             {
                 throw new CurrentPageException(String.Format("'{0}' is not the current page. Actual page was '{1}'", pageName, Browser.Location));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Base page without type.
+    /// </summary>
+    public abstract class BasePage : BasePage<BasePage>
+    {
+        public BasePage(BrowserSession browser) : base(browser){}
+
+        protected override void AssertView(bool condition)
+        {
+            if (!condition)
+            {
+                throw new CurrentPageException("Expected page does not pass the assert requirement.");
             }
         }
     }

--- a/Zukini.UI/Pages/BasePage.cs
+++ b/Zukini.UI/Pages/BasePage.cs
@@ -12,7 +12,10 @@ namespace Zukini.UI.Pages
         /// </summary>
         /// <param name="browser">An initialized instance of the WebDriver.</param>
         /// <exception cref="System.ArgumentNullException">driver</exception>
-        public BasePage(DriverScope browser) : base(browser){}
+        public BasePage(BrowserSession browser) : base(browser)
+        {
+            _browser = browser;
+        }
 
         /// <summary>
         /// Provides access to the BrowserSession (as provided by Coypu).
@@ -26,28 +29,14 @@ namespace Zukini.UI.Pages
         /// <param name="pageName">Name of the page to find (for messaging purposes.</param>
         /// <param name="condition"><c>true</c> if the page exists, or <c>false</c> if the page assertion fails.</param>
         /// <exception cref="Zukini.PageSupport.CurrentPageException"></exception>
-        protected virtual void AssertCurrentPage(string pageName, bool condition)
+        protected virtual TPage AssertCurrentPage(string pageName, bool condition)
         {
             if (!condition)
             {
                 throw new CurrentPageException(String.Format("'{0}' is not the current page. Actual page was '{1}'", pageName, Browser.Location));
             }
-        }
-    }
 
-    /// <summary>
-    /// Base page without type.
-    /// </summary>
-    public abstract class BasePage : BasePage<BasePage>
-    {
-        public BasePage(BrowserSession browser) : base(browser){}
-
-        protected override void AssertView(bool condition)
-        {
-            if (!condition)
-            {
-                throw new CurrentPageException("Expected page does not pass the assert requirement.");
-            }
+            return this as TPage;
         }
     }
 }

--- a/Zukini.UI/Pages/BaseView.cs
+++ b/Zukini.UI/Pages/BaseView.cs
@@ -44,7 +44,7 @@ namespace Zukini.UI.Pages
             }
             catch (Exception e)
             {
-                throw new Exception($"Expected '{typeof(TView)}' failed to load.\nReason: {e}");
+                throw new ZukiniAssertionException($"Expected '{typeof(TView)}' failed to load.\nReason: {e}");
             }
             return this as TView;
         }
@@ -62,7 +62,7 @@ namespace Zukini.UI.Pages
         protected virtual void AssertView(bool condition)
         {
             if (! condition)
-                throw new Exception($"Expected view '{typeof(TView)}' does not pass the assert requirement.");
+                throw new ZukiniAssertionException($"Expected view '{typeof(TView)}' does not pass the assert requirement.");
         }
     }
 }

--- a/Zukini.UI/Pages/BaseView.cs
+++ b/Zukini.UI/Pages/BaseView.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Coypu;
+using Coypu.Actions;
+using Coypu.Queries;
+
+namespace Zukini.UI.Pages
+{
+    /// <summary>
+    /// Contains generic stuff for pages and page components.
+    /// </summary>
+    /// <typeparam name="TView">Type of view</typeparam>
+    public abstract class BaseView<TView> : IView<TView> where TView : BaseView<TView>
+    {
+        private readonly DriverScope _browserScope;
+        private static readonly Options _NONE = new Options();
+        
+        /// <summary>
+        /// Actualy can be used as selector to find elements. Will be working differently for pages and components.
+        /// Alternative of $() from old framework. 
+        /// page      -> looks from the root of the doom
+        /// component -> looks inside parent scope (element, frame, window etc)
+        /// public Element SomeElement => _.FindCss("");
+        /// </summary>
+        protected virtual DriverScope _ => _browserScope;
+        
+        public BaseView(DriverScope browserScope)
+        {
+            if (browserScope == null)
+                throw new ArgumentNullException("driver");
+            _browserScope = browserScope;
+        }
+        
+        /// <summary>
+        /// Can be called to wait for IsLoaded to fire.
+        /// </summary>
+        /// <returns>TView</returns>
+        public virtual TView WaitToLoad()
+        {
+            try
+            {
+                if (IsLoaded()) return this as TView; // Load, so just immediately return this
+                var doNothing = new LambdaBrowserAction(() => {},  _NONE);
+                var predicate = new LambdaPredicateQuery(IsLoaded, _NONE);
+                _browserScope.TryUntil(doNothing, predicate);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Expected '{typeof(TView)}' failed to load.\nReason: {e}");
+            }
+            return this as TView;
+        }
+        
+        /// <summary>
+        /// Override this if you need to wait for custom wait condition on the page.
+        /// </summary>
+        /// <returns>true</returns> if IView is ready to be tested
+        public virtual bool IsLoaded() => true; // Yes it is loaded by default
+
+        /// <summary>
+        /// Can be used by Assert to verify the page / component meets the contract.
+        /// </summary>
+        /// <param name="condition">some condition to be tested</param>
+        protected virtual void AssertView(bool condition)
+        {
+            if (! condition)
+                throw new Exception($"Expected view '{typeof(TView)}' does not pass the assert requirement.");
+        }
+    }
+}

--- a/Zukini.UI/Pages/BaseView.cs
+++ b/Zukini.UI/Pages/BaseView.cs
@@ -16,7 +16,6 @@ namespace Zukini.UI.Pages
         
         /// <summary>
         /// Actualy can be used as selector to find elements. Will be working differently for pages and components.
-        /// Alternative of $() from old framework. 
         /// page      -> looks from the root of the doom
         /// component -> looks inside parent scope (element, frame, window etc)
         /// public Element SomeElement => _.FindCss("");

--- a/Zukini.UI/Pages/IView.cs
+++ b/Zukini.UI/Pages/IView.cs
@@ -1,0 +1,22 @@
+﻿
+namespace Zukini.UI.Pages
+{
+    public interface IView<out TView> where TView : class, IView<TView>
+    {
+        /// <summary>
+        /// Waits until IView is ready to be tested.
+        /// </summary>
+        /// <returns>TView</returns> constructed IView
+        TView WaitToLoad();
+        
+        /// <summary>
+        ///  Condition to be waited for. 
+        /// <code>
+        ///     public override bool IsLoaded() => 
+        ///         new List<ElementScope> {Element1, Element2, ... , Elemen3}.FindAll(it => ! it.Exists()).Any();
+        /// </code>
+        /// </summary>
+        /// <returns>true</returns> if IView is loaded
+        bool IsLoaded();
+    }
+}

--- a/Zukini.UI/Pages/IView.cs
+++ b/Zukini.UI/Pages/IView.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Zukini.UI.Pages
 {
-    public interface IView<out TView> where TView : class, IView<TView>
+    public interface IView<out TView> where TView : class
     {
         /// <summary>
         /// Waits until IView is ready to be tested.

--- a/Zukini.UI/Pages/IViewFactory.cs
+++ b/Zukini.UI/Pages/IViewFactory.cs
@@ -19,7 +19,7 @@ namespace Zukini.UI.Pages
         /// <typeparam name="TView">Type of view</typeparam>
         /// <returns>IView</returns>
         TView Load<TView>() where TView : class, IView<TView>;
-
+        
         /// <summary>
         /// This maybe used for Views with parent scope, like components.
         /// <code>

--- a/Zukini.UI/Pages/IViewFactory.cs
+++ b/Zukini.UI/Pages/IViewFactory.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using Coypu;
+
+namespace Zukini.UI.Pages
+{
+    public interface IViewFactory
+    {   
+        /// <summary>
+        /// Constructs an IView. Similar to new IView with dependencies resolution. 
+        /// </summary>
+        /// <typeparam name="TView">Type of view</typeparam>
+        /// <returns>IView</returns>
+        TView Get<TView>() where TView : class, IView<TView>;
+
+        /// <summary>
+        /// Constructs an IView and calls post construction methods, like IView#WaitToLoad.
+        /// </summary>
+        /// <typeparam name="TView">Type of view</typeparam>
+        /// <returns>IView</returns>
+        TView Load<TView>() where TView : class, IView<TView>;
+
+        /// <summary>
+        /// This maybe used for Views with parent scope, like components.
+        /// <code>
+        /// public class Activity : BaseComponent<Activity>
+        /// {
+        ///     public Activity(BrowserSession browser, DriverScope scope) : base(browser, scope){ }
+        ///     public ElementScope Status => _.FindCss(".status");
+        /// }
+        /// </code>
+        /// To construct it with view factory:
+        /// <code>
+        /// _factory.Get(() => new Activity(Browser, _.FindCss("parentSelector")));
+        /// </code> 
+        /// </summary>
+        /// <typeparam name="TView">to be constructed</typeparam>
+        /// <param name="supplier">how to create a view</param>
+        /// <returns></returns>
+        TView Get<TView>(Func<TView> supplier) where TView : class, IView<TView>;
+
+        /// <summary>
+        /// The same as this#Get, but also will execute post constuction steps. Like wait for it.
+        /// </summary>
+        /// <typeparam name="TView">to be constructed</typeparam>
+        /// <param name="supplier">how to construct</param>
+        /// <returns></returns>
+        TView Load<TView>(Func<TView> supplier) where TView : class, IView<TView>;
+
+        /// <summary>
+        /// Converts a sequence of ElementScope to a sequence of IView.
+        /// <code>
+        /// IEnumerable<Activity> many = _factory.GetAll(Activities, it => new Activity(_session, it))
+        /// </code> 
+        /// </summary>
+        /// <typeparam name="TView"></typeparam>
+        /// <typeparam name="TScope"></typeparam>
+        /// <param name="elements"></param>
+        /// <param name="mapFunc"></param>
+        /// <returns></returns>
+        IEnumerable<TView> GetAll<TView, TScope>(IEnumerable<TScope> elements,
+            Func<TScope, TView> mapFunc)
+            where TView : class, IView<TView>
+            where TScope : DriverScope;
+
+        /// <summary>
+        /// Converts a sequence of ElementScope to a sequence of IView.
+        /// <code>
+        /// IEnumerable<Activity> many = _factory.GetAll<Activity>(Activities);
+        /// </code> 
+        /// </summary>
+        /// <typeparam name="TView"></typeparam>
+        /// <param name="elements"></param>
+        /// <returns></returns>
+        IEnumerable<TView> GetAll<TView>(IEnumerable<DriverScope> elements)
+                                         where TView : BaseComponent<TView>;
+
+        /// <summary>
+        /// Converts a sequence of ElementScope to a sequence of IView with post constuction actions, like wait.
+        /// <code>
+        /// IEnumerable<Activity> many = _factory.LoadAll(Activities, it => new Activity(_session, it)) 
+        /// </code> 
+        /// + call WaitToLoad on each Activity object.
+        /// </summary>
+        /// <typeparam name="TView"></typeparam>
+        /// <typeparam name="TScope"></typeparam>
+        /// <param name="elements"></param>
+        /// <param name="mapFunc"></param>
+        /// <returns></returns>
+        IEnumerable<TView> LoadAll<TView, TScope>(IEnumerable<TScope> elements, 
+                                         Func<TScope, TView> mapFunc) 
+                                         where TView : class, IView<TView>
+                                         where TScope : DriverScope;
+
+        /// <summary>
+        /// Converts a sequence of ElementScope to a sequence of BaseComponent with post constuction actions, like wait.
+        /// </summary>
+        /// <typeparam name="TView"></typeparam>
+        /// <param name="elements"></param>
+        /// <returns></returns>
+        IEnumerable<TView> LoadAll<TView>(IEnumerable<DriverScope> elements) where TView : BaseComponent<TView>;
+    }
+}

--- a/Zukini.UI/Pages/ViewFactory.cs
+++ b/Zukini.UI/Pages/ViewFactory.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BoDi;
+using Coypu;
+
+namespace Zukini.UI.Pages
+{
+    public class ViewFactory : IViewFactory
+    {
+        private readonly IObjectContainer _container;
+
+        /// <summary>
+        /// Containter with all the bindings.
+        /// </summary>
+        /// <param name="container"></param>
+        public ViewFactory(IObjectContainer container)
+        {
+            _container = container;
+        }
+
+        /// <inheritdoc />
+        public TView Get<TView>() where TView : class, IView<TView> 
+            => _container.Resolve<TView>();
+
+        /// <inheritdoc />
+        public TView Load<TView>() where TView : class, IView<TView> 
+            => Get<TView>().WaitToLoad();
+
+        /// <inheritdoc />
+        public TView Get<TView>(Func<TView> supplier) where TView : class, IView<TView> 
+            => supplier.Invoke();
+
+        /// <inheritdoc />
+        public TView Load<TView>(Func<TView> supplier) where TView : class, IView<TView> 
+            => Get(supplier).WaitToLoad();
+
+        /// <inheritdoc />
+        public IEnumerable<TView> GetAll<TView, TScope>(IEnumerable<TScope> elements, Func<TScope, TView> mapFunc)
+            where TView : class, IView<TView> 
+            where TScope : DriverScope
+            => elements.Select(mapFunc);
+
+        /// <inheritdoc />
+        public IEnumerable<TView> GetAll<TView>(IEnumerable<DriverScope> elements)
+            where TView : BaseComponent<TView>
+        {
+            Func<DriverScope, TView> mapFunc = it => (TView) Activator.CreateInstance(typeof(TView), it);
+            return GetAll(elements, mapFunc);
+        }
+        
+        /// <inheritdoc />
+        public IEnumerable<TView> LoadAll<TView, TScope>(IEnumerable<TScope> elements, Func<TScope, TView> mapFunc) 
+            where TView : class, IView<TView>
+            where TScope : DriverScope
+            => GetAll(elements, mapFunc).Select(it => it.WaitToLoad());
+
+        /// <inheritdoc />
+        public IEnumerable<TView> LoadAll<TView>(IEnumerable<DriverScope> elements)
+            where TView : BaseComponent<TView>
+            => GetAll<TView>(elements).Select(it => it.WaitToLoad());
+        
+        // TODO Attributes processor. Factory takes a map {Actibute, Action} with registered attributes
+        // Example: [WaitOnLoad] which will automatically redirect the call wait.
+        // [Listener = Some] to register Javascript listener... ETC.
+    }
+}

--- a/Zukini.UI/Pages/ViewFactory/BasePage.cs
+++ b/Zukini.UI/Pages/ViewFactory/BasePage.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Coypu;
+
+namespace CCC_Infrastructure.ViewFactory
+{
+    public abstract class BasePage<TPage> : BaseView<TPage> where TPage : BasePage<TPage>
+    {
+        private BrowserSession _browser;
+
+        /// <summary>
+        /// This is browser to operate.
+        /// </summary>
+        protected virtual BrowserSession Browser => _browser;
+
+        public BasePage(BrowserSession browser) : base(browser)
+        {
+            _browser = browser;
+        }
+        
+        protected virtual void AssertCurrentPage(string pageName, bool condition)
+        {
+            if (!condition)
+                throw new Exception($"Expected page '{pageName}' does not pass the assert requirement.");
+        }
+    }
+}

--- a/Zukini.UI/Zukini.UI.csproj
+++ b/Zukini.UI/Zukini.UI.csproj
@@ -60,6 +60,11 @@
     <Compile Include="CoypuExtensions.cs" />
     <Compile Include="BrowserSessionExtension.cs" />
     <Compile Include="ElementScopeExtension.cs" />
+    <Compile Include="Pages\BaseComponent.cs" />
+    <Compile Include="Pages\BaseView.cs" />
+    <Compile Include="Pages\IView.cs" />
+    <Compile Include="Pages\IViewFactory.cs" />
+    <Compile Include="Pages\ViewFactory.cs" />
     <Compile Include="Steps\UISteps.cs" />
     <Compile Include="UIHooks.cs" />
     <Compile Include="Pages\BasePage.cs" />


### PR DESCRIPTION
**Motivation**

- Reuse of common components. Encourage composition over inheritance.
- Provide sound approach on waits in a single place of view object.
- View, Page and Component architecture, following S.O.L.I.D principles.
- Use of Dependency Injection pattern and assistance in wiring objects (at least for pages atm).  

**What is page (BasePage)?**

You open a browser and see the page. Page is a standalone independent view, which means DriverScope is BrowserSession or browser itself (Check BasePage, BaseView constructors). 

**What is BaseComponent?**

Component can be part of the page, so effectively relative part or standalone component.  

You can standardize components and make these reusable. If tomorrow these change - all you have to do is to change one single class related to it.

**How BaseComponent differs from page?**

If BaseComponent is relative - it could have parent element or parent scope.

**What is BaseView?**

Share common functionality between the BasePage and BaseComponent. Everything that is not a page or component. 

**How to create a page object via Factory?**
```
private IViewFactory _viewFactory;

public MyPageSteps(IObjectContainer objectContainer, IViewFactory viewFactory) : base(objectContainer)
{
           _viewFactory = viewFactory;
}

private MyPage ActivitiesPage => _viewFactory.Load<MyPage>();
```

**How to create relative Component via Factory?**
```
/// Single element

var single1 = _factory.Load<SomeComponent>(); // No parent
var single2 = _factory.Load(() => new SomeComponent(_.FindCss("ParentSelector"))); // With parent element

/// Many
var many1  = _viewFactory.LoadAll<SomeComponent>(_.FindAllCss("ParentSelector"));
var many2  = _factory.LoadAll(_.FindAllCss("ParentSelector"), it => new SomeComponent(it));
```
 
**What does IViewFactory # Load mean?**
1. Wire registered dependencies. [In our example above - browser].
2. Creates page instance.
3. Calls WaitOnLoad method.
4. WaitOnLoad poll IsLoaded.

**WaitOnLoad and IsLoaded?**

WaitOnLoad will be called, after the View (Page or Component) is created. WaitOnLoad waits until IsLoaded is true, using polling action. Can be anything. You can override it on your convenience.
For example poll for element to appear, so effectively wait for the page.